### PR TITLE
Resolve #11: Added warning about memory leak 

### DIFF
--- a/src/FwPrDCreate.h
+++ b/src/FwPrDCreate.h
@@ -27,7 +27,9 @@
  *
  * The creation and the extension functions in this header file always check the
  * success of calls to <code>malloc</code>.
- * In case of failure, the caller aborts and returns a NULL pointer.
+ * In case of failure, the function aborts and returns a NULL pointer.
+ * Memory which had already been allocated at the time the function aborts,
+ * is not released.
  *
  * Applications which do not wish to use dynamic memory allocation can
  * create a procedure descriptor statically using the services offered

--- a/src/FwSmDCreate.h
+++ b/src/FwSmDCreate.h
@@ -27,7 +27,9 @@
  *
  * The creation and the extension functions in this header file always check the
  * success of calls to <code>malloc</code>.
- * In case of failure, the caller aborts and returns a NULL pointer.
+ * In case of failure, the function aborts and returns a NULL pointer.
+ * Memory which had already been allocated at the time the function aborts,
+ * is not released.
  *
  * Applications which do not wish to use dynamic memory allocation can
  * create a state machine descriptor statically using the services offered


### PR DESCRIPTION
A memory leak may occur if a call to `malloc` fails in  configuration function after that function has already successfully allocated memory. I have added a warning about this in the doxygen comments of the State Machine and Procedure modules.